### PR TITLE
Fix diagonal movement

### DIFF
--- a/com/haxepunk/ai/path/NodeGraph.hx
+++ b/com/haxepunk/ai/path/NodeGraph.hx
@@ -108,10 +108,16 @@ class NodeGraph
 
 				if (allowDiagonal)
 				{
-					node.addNeighbor(getNode(x - 1, y - 1), DIAGONAL_COST);
-					node.addNeighbor(getNode(x + 1, y - 1), DIAGONAL_COST);
-					node.addNeighbor(getNode(x - 1, y + 1), DIAGONAL_COST);
-					node.addNeighbor(getNode(x + 1, y + 1), DIAGONAL_COST);
+                    if(!grid.getTile(x, y - 1))
+                    {
+                        if(!grid.getTile(x - 1, y)) node.addNeighbor(getNode(x - 1, y - 1), DIAGONAL_COST);
+                        if(!grid.getTile(x + 1, y)) node.addNeighbor(getNode(x + 1, y - 1), DIAGONAL_COST);
+                    }
+                    if(!grid.getTile(x, y + 1))
+                    {
+                        if(!grid.getTile(x - 1, y)) node.addNeighbor(getNode(x - 1, y + 1), DIAGONAL_COST);
+                        if(!grid.getTile(x + 1, y)) node.addNeighbor(getNode(x + 1, y + 1), DIAGONAL_COST);
+                    }
 				}
 				addNode(node);
 			}

--- a/com/haxepunk/ai/path/NodeGraph.hx
+++ b/com/haxepunk/ai/path/NodeGraph.hx
@@ -108,16 +108,16 @@ class NodeGraph
 
 				if (allowDiagonal)
 				{
-                    if(!grid.getTile(x, y - 1))
-                    {
-                        if(!grid.getTile(x - 1, y)) node.addNeighbor(getNode(x - 1, y - 1), DIAGONAL_COST);
-                        if(!grid.getTile(x + 1, y)) node.addNeighbor(getNode(x + 1, y - 1), DIAGONAL_COST);
-                    }
-                    if(!grid.getTile(x, y + 1))
-                    {
-                        if(!grid.getTile(x - 1, y)) node.addNeighbor(getNode(x - 1, y + 1), DIAGONAL_COST);
-                        if(!grid.getTile(x + 1, y)) node.addNeighbor(getNode(x + 1, y + 1), DIAGONAL_COST);
-                    }
+					if(!grid.getTile(x, y - 1))
+					{
+						if(!grid.getTile(x - 1, y)) node.addNeighbor(getNode(x - 1, y - 1), DIAGONAL_COST);
+						if(!grid.getTile(x + 1, y)) node.addNeighbor(getNode(x + 1, y - 1), DIAGONAL_COST);
+					}
+					if(!grid.getTile(x, y + 1))
+					{
+						if(!grid.getTile(x - 1, y)) node.addNeighbor(getNode(x - 1, y + 1), DIAGONAL_COST);
+						if(!grid.getTile(x + 1, y)) node.addNeighbor(getNode(x + 1, y + 1), DIAGONAL_COST);
+					}
 				}
 				addNode(node);
 			}


### PR DESCRIPTION
Entities were able to execute diagonal moves that made them cross one or two illegal tiles. 
